### PR TITLE
fixes #108 by emphasizing inclusion of jags model

### DIFF
--- a/R/metab.R
+++ b/R/metab.R
@@ -36,13 +36,14 @@
 #'@param do.obs.name the name of the column in data containing the DO observations (in mg/L) to be used as the response variable
 #'@param ... arguments to be passed on to the metabolism model specified by \code{method}
 #'
-#'@return A data.frame containing columns for year, doy (day of year, julian day plus fraction of day), GPP, R, and NEP
-#'\item{year}{integer year}
-#'\item{doy}{numeric, day of year + fraction of day, where the day is the julian day, and a fraction of 0.5 corresponds to noon}
-#'\item{GPP}{numeric, gross primary production, in units of mg O2 per liter per day. By convention, this value is positive.}
-#'\item{R}{numeric, respiration, in units of mg O2 per liter per day. By convention, this value is negative}
-#'\item{NEP}{numeric, net ecosystem production, in units of mg O2 per liter per day. For most methods this equal GPP+R, but this is not necessarily the case for \code{"method"="bookkeep"}}
-#' Note that different models will have different \link{attributes} attached to them.
+#' @return 
+#' A data.frame containing columns for year, doy (day of year, julian day plus fraction of day), GPP, R, and NEP
+#' \item{year}{integer year}
+#' \item{doy}{numeric, day of year + fraction of day, where the day is the julian day, and a fraction of 0.5 corresponds to noon}
+#' \item{GPP}{numeric, gross primary production, in units of mg O2 per liter per day. By convention, this value is positive.}
+#' \item{R}{numeric, respiration, in units of mg O2 per liter per day. By convention, this value is negative}
+#' \item{NEP}{numeric, net ecosystem production, in units of mg O2 per liter per day. For most methods this equal GPP+R, but this is not necessarily the case for \code{"method"="bookkeep"}}
+#' Note that different models will have different \link{attributes} attached to them. See examples. 
 
 #'@keywords metabolism
 #'
@@ -97,7 +98,12 @@
 #' 
 #' # example attributes
 #' names(attributes(m.ols))
-#' attributes(m.ols)$mod
+#' attr(m.ols, "mod")
+#'  
+#' # To get full JAGS model
+#' # including posterior draws:
+#' \dontrun{names(attributes(m.bay))}
+#' \dontrun{attr(m.bay, "model")}
 #'
 #'@export
 

--- a/R/metab.bayesian.R
+++ b/R/metab.bayesian.R
@@ -193,13 +193,19 @@ bayesFit <- function(data, params, mf, tend="median", ...){ #function that write
 #'@param wtr Vector of water temperatures in \eqn{^{\circ}C}{degrees C}. Used in scaling respiration with temperature
 #'@param priors Parameter priors supplied as a named numeric vector (example: c("gppMu"=0, "gppSig2"=1E5, "rMu"=0, "rSig2"=1E5, "kSig2"=NA))
 #'@param ... additional arguments; currently "datetime" is the only recognized argument passed through \code{...}
-#'@return
-#'A data.frame with columns corresponding to components of metabolism 
-#'\describe{
-	#'\item{GPP}{numeric estimate of Gross Primary Production, \eqn{mg O_2 L^{-1} d^{-1}}{mg O2 / L / d}}
-	#'\item{R}{numeric estimate of Respiration, \eqn{mg O_2 L^{-1} d^{-1}}{mg O2 / L / d}}
-	#'\item{NEP}{numeric estimate of Net Ecosystem production, \eqn{mg O_2 L^{-1} d^{-1}}{mg O2 / L / d}}
-#'}
+#' @return
+#' A list of length 4 with components:
+	#' \item{model}{the jags model, including posterior draws (see \link{jags})}
+	#' \item{params}{parameter estimates of interest from model (medians)}
+	#' \item{metab.sd}{standard deviation of metabolism estimates}
+	#' \item{metab}{daily metabolism estimates as a data.frame with columns corresponding to
+	#' \describe{
+		#' \item{\code{GPP}}{numeric estimate of Gross Primary Production, \eqn{mg O_2 L^{-1} d^{-1}}{mg O2 / L / d}}  
+		#' \item{\code{R}}{numeric estimate of Respiration, \eqn{mg O_2 L^{-1} d^{-1}}{mg O2 / L / d}}  
+		#' \item{\code{NEP}}{numeric estimate of Net Ecosystem production, \eqn{mg O_2 L^{-1} d^{-1}}{mg O2 / L / d}}  
+	#' }}
+
+
 #'@references
 #'Holtgrieve, Gordon W., Daniel E. Schindler, Trevor a. Branch, and Z. Teresa A'mar. 
 #'2010. \emph{Simultaneous Quantification of Aquatic Ecosystem Metabolism and Reaeration 

--- a/man/metab.Rd
+++ b/man/metab.Rd
@@ -43,7 +43,7 @@ A data.frame containing columns for year, doy (day of year, julian day plus frac
 \item{GPP}{numeric, gross primary production, in units of mg O2 per liter per day. By convention, this value is positive.}
 \item{R}{numeric, respiration, in units of mg O2 per liter per day. By convention, this value is negative}
 \item{NEP}{numeric, net ecosystem production, in units of mg O2 per liter per day. For most methods this equal GPP+R, but this is not necessarily the case for \code{"method"="bookkeep"}}
-Note that different models will have different \link{attributes} attached to them.
+Note that different models will have different \link{attributes} attached to them. See examples.
 }
 \description{
 Returns daily time series of gross primary production (GPP), respiration (R), and net ecosystem production (NEP). Depending on the method used, other information may be returned as well. Calculations are made using one of 5 statistical methods.
@@ -83,7 +83,12 @@ Returns daily time series of gross primary production (GPP), respiration (R), an
 
 # example attributes
 names(attributes(m.ols))
-attributes(m.ols)$mod
+attr(m.ols, "mod")
+
+# To get full JAGS model
+# including posterior draws:
+\dontrun{names(attributes(m.bay))}
+\dontrun{attr(m.bay, "model")}
 }
 \author{
 Ryan D. Batt

--- a/man/metab.bayesian.Rd
+++ b/man/metab.bayesian.Rd
@@ -25,12 +25,16 @@ metab.bayesian(do.obs, do.sat, k.gas, z.mix, irr, wtr, priors, ...)
 \item{...}{additional arguments; currently "datetime" is the only recognized argument passed through \code{...}}
 }
 \value{
-A data.frame with columns corresponding to components of metabolism
+A list of length 4 with components:
+\item{model}{the jags model, including posterior draws (see \link{jags})}
+\item{params}{parameter estimates of interest from model (medians)}
+\item{metab.sd}{standard deviation of metabolism estimates}
+\item{metab}{daily metabolism estimates as a data.frame with columns corresponding to
 \describe{
-\item{GPP}{numeric estimate of Gross Primary Production, \eqn{mg O_2 L^{-1} d^{-1}}{mg O2 / L / d}}
-\item{R}{numeric estimate of Respiration, \eqn{mg O_2 L^{-1} d^{-1}}{mg O2 / L / d}}
-\item{NEP}{numeric estimate of Net Ecosystem production, \eqn{mg O_2 L^{-1} d^{-1}}{mg O2 / L / d}}
-}
+\item{\code{GPP}}{numeric estimate of Gross Primary Production, \eqn{mg O_2 L^{-1} d^{-1}}{mg O2 / L / d}}
+\item{\code{R}}{numeric estimate of Respiration, \eqn{mg O_2 L^{-1} d^{-1}}{mg O2 / L / d}}
+\item{\code{NEP}}{numeric estimate of Net Ecosystem production, \eqn{mg O_2 L^{-1} d^{-1}}{mg O2 / L / d}}
+}}
 }
 \description{
 This function runs the bayesian metabolism model on the supplied


### PR DESCRIPTION
@jzwart and @lawinslow I think this satisfies the reviewers request concerning the Bayes model returning the posterior draws. They were attached as attributes in `metab`, and returned as the first item of the list in `metab.bayes`. `metab.bayes` documentation now makes it clear that this is item 1 of the list returned, and the documentation for `metab` now gives an example of how to access the model attribute.
